### PR TITLE
Fixed transition on background-color squares

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -76,7 +76,7 @@ const Home = () => {
         <div className="row">
           {/* map is an array function which maps each value */}
           {hexcode.map((hex, i) => (
-            <div className="row-child" key={`${hex}-${i}`}>
+            <div className="row-child" key={i}>
               <div
                 className="square"
                 style={{ backgroundColor: `${hex}` }}


### PR DESCRIPTION
The background-color transition effect would not always work as the map of squares most likely had a new key and resulting in no transition when the "Random Color" button was pushed.

By removing the hex variable from the key, React can now keep track of the element rendered and the background-color transition is applied.

See issue #43.