### PR TITLE
Show one box after win

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -95,30 +95,35 @@ const Home = () => {
       </div>
       <div id="container">
         <div className="row">
-          {/* map is an array function which maps each value */}
-          {hexcode.map((hex, i) => (
+          {isWin ? 
+            (
+              <div className="row-child">
+                <div
+                  className="square"
+                  style={{ backgroundColor: `${endColor}` }}  >
+                  <span>
+                    <button
+                            className="btn"
+                            onClick={() => copyColorToClipboard(endColor)}
+                            style={{backgroundColor: `${endColor}`}}>
+                            Copy Color
+                      </button>
+                    </span>
+                </div>
+                </div>
+            )
+          : hexcode.map((hex, i) => (
             <div className="row-child" key={i}>
               <div
                 className="square"
                 style={{ backgroundColor: `${hex}` }}
                 onClick={() => checkColor(hex)}
               >
-                <span>
-                  {isWin && (
-                    <button
-                      className="btn"
-                      onClick={() => copyColorToClipboard(endColor)}
-                      style={{
-                        backgroundColor: isWin === true ? `${endColor}` : "",
-                      }}
-                    >
-                      Copy Color
-                    </button>
-                  )}
-                </span>
               </div>
             </div>
-          ))}
+          ))
+          
+          }
         </div>
       </div>
       <ToastContainer autoClose={800} hideProgressBar={true} />


### PR DESCRIPTION
Closes #77 

## 🛠️ Fixes Issue: "#77 Deprecate showing multiple buttons for the same color"


## 👨‍💻 Changes proposed:

After winning, instead of showing 6 boxes with the same colour, only one box with the correct color and copy to clipboard functionality is shown at the centre.

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x ] My code follows the code style of this project.
- [ x] This PR does not contain plagiarized content.
- [ ]x The title of my pull request is a short description of the requested changes.
- [x] I am a participant of Hacktoberfest 2022

## 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots

![image](https://user-images.githubusercontent.com/60972451/196732788-7c7d0e7c-adc8-45e9-ac04-77f4de48cd70.png)
